### PR TITLE
Fixed month abbreviation for february

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -8,7 +8,7 @@ var cheerio = require('cheerio');
 var dateFormat = require('dateformat');
 var fs = require('fs');
 
-var monthNames = ["jan", "fev", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
+var monthNames = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"];
 var dateRef  = process.argv[2];
 var dateEnd  = process.argv[3];
 var viewJson = process.argv[4];


### PR DESCRIPTION
The month abbreviation for february was incorrect, causing it to load an entire week of events instead of the selected date.